### PR TITLE
Incremento de timeout en pruebas unitarias con Mocha y Sinon

### DIFF
--- a/tests/sinonTests.ts
+++ b/tests/sinonTests.ts
@@ -19,7 +19,9 @@ const mockTeamFindByPk = sinon.stub(Team, 'findByPk');
 const mockTeamUpdate = sinon.stub(Team, 'update');
 const mockTeamDestroy = sinon.stub(Team.prototype, 'destroy');
 
-describe('API Tests', () => {
+describe('API Tests', function () {
+  this.timeout(5000);
+
   beforeEach(() => {
     sinon.reset();
     mockUserCreate.reset();


### PR DESCRIPTION
- Se aumentó la duración del tiempo de espera (timeout) en las pruebas de Mocha de 2 segundos a 5 segundos
- El tiempo de espera inicial de 2 segundos estaba causando que la primera ejecución de `npm test` fallara, posiblemente relacionado con la creación inicial de tablas en la base de datos simulada