### PR TITLE
Eliminación de clave de API-Football de docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       DB_USER: postgres
       DB_PASSWORD: 8492
       DB_DATABASE: footmanager
-      API_FOOTBALL_KEY: 2d2c7fbcfab3bc3e599e453d1fcbbfaa
+      API_FOOTBALL_KEY: ${API_FOOTBALL_KEY}
+    env_file:
+      - .env
     depends_on:
       - db
 


### PR DESCRIPTION
- Se eliminó la clave real de API-Football del archivo `docker-copose.yml`, la cual había sido incluida a efectos de simplificar el proceso, por una referencia dinámica al archivo .env que el usuario debe crear